### PR TITLE
Add archival notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # relyance-sci-action
 
+> **ARCHIVED**: This action is no longer maintained and has been removed from all repositories.
+
 Downloads and runs Relyance's source code scanning binary for integration purposes.
 
-Required: a `relyance.yaml` configuration file in the root of the project.
-
-See [Relyance's integration settings](https://playco.relyance.ai/#/config/sourceCodeAnalyzer) for more details.
+## Repos that used this action
+- buruburu, spellpals, tourneywing, everstory, everwing
+- homeRenovation, sroyale-org, concept-push, trembly-fb, archery-safari
+- degen-wars, catlife, everwing-arcade, streetroyale, kaito-message
+- baseball, dragon-concept-token-auth, dragon-concept2, dragon-concept
+- concept-push2, pets-concept2, dragon-concept3, garden-match-old
+- cafe-match, pets-concept, heartbeats, heartbeats2, baseball-v030
+- base-game, trembly, slippy-cat, thuglife-tg, thugmaster


### PR DESCRIPTION
This action is being deprecated. Adding archival notice before archiving the repository.

Tracking issue: #5